### PR TITLE
Add descendant extraction functionality with depth control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ credentials.txt
 token.txt
 auth.sh 
 CLAUDE.md
+
+# Test data
+test-data/

--- a/jira_extractor/cli.py
+++ b/jira_extractor/cli.py
@@ -92,11 +92,11 @@ def write_output(data: Dict[str, Any], output_path: str, issue_key: str, overwri
         print(f"Metadata saved to {metadata_path}")
 
 
-def write_multiple_issues(issues: Dict[str, Dict[str, Any]], output_path: str, 
-                         overwrite: bool = False, expand: Optional[str] = None, 
-                         extraction_metadata: Optional[Dict[str, Any]] = None):
+def write_multiple_issues(issues: Dict[str, Dict[str, Any]], output_path: str,
+                          overwrite: bool = False, expand: Optional[str] = None,
+                          extraction_metadata: Optional[Dict[str, Any]] = None):
     """Write multiple issues and their relationships to output destination"""
-    
+
     if output_path in ['-', 'stdout']:
         # Output all issues as a single JSON object to stdout
         output_data = {
@@ -108,7 +108,7 @@ def write_multiple_issues(issues: Dict[str, Dict[str, Any]], output_path: str,
     else:
         # Output to directory - each issue in separate file
         os.makedirs(output_path, exist_ok=True)
-        
+
         # Track extraction summary
         extraction_summary = {
             "extraction_timestamp": datetime.now().isoformat(),
@@ -117,7 +117,7 @@ def write_multiple_issues(issues: Dict[str, Dict[str, Any]], output_path: str,
             "issue_keys": list(issues.keys()),
             "expand_parameter": expand
         }
-        
+
         # Write each issue to separate file
         for issue_key, issue_data in issues.items():
             file_path = os.path.join(output_path, f"{issue_key}.json")
@@ -157,7 +157,7 @@ def write_multiple_issues(issues: Dict[str, Dict[str, Any]], output_path: str,
         summary_path = os.path.join(output_path, "_extraction_summary.json")
         with open(summary_path, 'w', encoding='utf-8') as f:
             json.dump(extraction_summary, f, indent=2, ensure_ascii=False)
-        
+
         print(f"Extraction summary saved to {summary_path}")
         print(f"Total issues extracted: {len(issues)}")
 
@@ -173,11 +173,11 @@ Examples:
   %(prog)s -u https://issues.redhat.com -i RFE-7877 --bearer-token abc123
   %(prog)s -u https://issues.redhat.com -i RFE-7877 --username $USER --token abc123
   %(prog)s -u https://issues.redhat.com -i RFE-7877 --username $USER --password
-  
+
   # Descendant extraction with depth control
   %(prog)s -u https://issues.redhat.com -i RFE-7877 --descendant-depth 2 --include-subtasks --bearer-token abc123
   %(prog)s -u https://issues.redhat.com -i RFE-7877 --desc-depth all --include-links --username $USER --token abc123
-  
+
   # Multiple relationship types with file output
   %(prog)s -u https://issues.redhat.com -i RFE-7877 --descendant-depth 3 --include-subtasks --include-links -o ./output --bearer-token abc123
         """
@@ -208,13 +208,13 @@ Examples:
     # Relationship traversal options
     relationship_group = parser.add_argument_group('Relationship Traversal')
     relationship_group.add_argument('--descendant-depth', '--desc-depth', default='0',
-                                   help='Maximum descendant traversal depth: 0 (target only), N (N levels), or "all" (unlimited)')
+                                    help='Maximum descendant traversal depth: 0 (target only), N (N levels), or "all" (unlimited)')
     relationship_group.add_argument('--include-subtasks', action='store_true',
-                                   help='Include subtask relationships in traversal')
+                                    help='Include subtask relationships in traversal')
     relationship_group.add_argument('--include-links', action='store_true',
-                                   help='Include issue links in traversal')
+                                    help='Include issue links in traversal')
     relationship_group.add_argument('--include-remote-links', action='store_true',
-                                   help='Include remote links in traversal')
+                                    help='Include remote links in traversal')
 
     # Debug options
     parser.add_argument('--debug', action='store_true', help='Enable debug logging')
@@ -224,13 +224,13 @@ Examples:
 
 def parse_depth(depth_str: str) -> int:
     """Parse depth parameter into integer or -1 for unlimited
-    
+
     Args:
         depth_str: Depth string ('0', '1', '2', ..., 'all')
-        
+
     Returns:
         Non-negative integer for limited depth, -1 for unlimited depth
-        
+
     Raises:
         ValueError: If depth_str is invalid
     """
@@ -296,10 +296,10 @@ def main():
 
     # Determine if descendant extraction is requested
     has_descendant_options = (
-        descendant_depth > 0 or descendant_depth == -1 or 
-        args.include_subtasks or 
-        args.include_links or 
-        args.include_remote_links
+        (descendant_depth > 0 or descendant_depth == -1)
+        or args.include_subtasks
+        or args.include_links
+        or args.include_remote_links
     )
 
     try:
@@ -317,7 +317,7 @@ def main():
         if has_descendant_options:
             # Descendant extraction mode
             logging.info(f"Extracting issue {args.issue} with descendants (depth: {descendant_depth if descendant_depth != -1 else 'unlimited'})")
-            
+
             # Log extraction options
             if args.include_subtasks:
                 logging.info("Including subtask relationships")
@@ -325,35 +325,35 @@ def main():
                 logging.info("Including issue links")
             if args.include_remote_links:
                 logging.info("Including remote links")
-            
+
             # Fetch issue and descendants
             issues_data = client.get_descendants(
-                args.issue, 
+                args.issue,
                 depth=descendant_depth,
                 include_subtasks=args.include_subtasks,
                 include_links=args.include_links,
                 include_remote_links=args.include_remote_links,
                 expand=args.expand
             )
-            
+
             # Extract metadata and issues
             extraction_metadata = issues_data.pop("_extraction_metadata", {})
-            
+
             if not issues_data:
                 logging.warning("No issues were extracted")
                 sys.exit(1)
-            
+
             logging.info(f"Successfully extracted {len(issues_data)} issues")
-            
+
             # Write output
             write_multiple_issues(
-                issues_data, 
-                args.output, 
-                args.overwrite, 
+                issues_data,
+                args.output,
+                args.overwrite,
                 args.expand,
                 extraction_metadata
             )
-            
+
         else:
             # Single issue extraction mode (original behavior)
             logging.info(f"Fetching single issue: {args.issue}")

--- a/jira_extractor/client.py
+++ b/jira_extractor/client.py
@@ -9,7 +9,7 @@ This program is licensed under GPL-3.0-or-later
 
 import logging
 from urllib.parse import urljoin
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, Set, List
 
 import requests
 from requests.auth import HTTPBasicAuth
@@ -71,6 +71,50 @@ class JiraClient:
         else:
             raise ValueError(f"Unsupported auth method: {auth_method}")
 
+    def _make_api_request(self, url: str, params: Optional[Dict[str, Any]] = None, 
+                         resource_name: str = "resource", 
+                         handle_404_as_empty: bool = False) -> Any:
+        """
+        Make an API request with centralized error handling
+        
+        Args:
+            url: API endpoint URL
+            params: Query parameters
+            resource_name: Name of resource for error messages
+            handle_404_as_empty: If True, return empty list for 404 errors
+            
+        Returns:
+            JSON response data or empty list for 404 when handle_404_as_empty=True
+            
+        Raises:
+            Exception: For authentication, permission, or HTTP errors
+        """
+        logging.debug(f"Making API request to: {url}")
+        if params:
+            logging.debug(f"Query parameters: {params}")
+        
+        response = self.session.get(url, params=params or {})
+        
+        # Log response details for debugging
+        logging.debug(f"Response status: {response.status_code}")
+        logging.debug(f"Response headers: {dict(response.headers)}")
+        
+        # Handle common error cases
+        if response.status_code == 401:
+            raise Exception("Authentication failed. Please check your credentials.")
+        elif response.status_code == 403:
+            raise Exception(f"Access denied to {resource_name}. Check permissions.")
+        elif response.status_code == 404:
+            if handle_404_as_empty:
+                return []
+            else:
+                raise Exception(f"{resource_name} not found.")
+        
+        # Handle any other HTTP errors
+        response.raise_for_status()
+        
+        return response.json()
+
     def get_issue(self, issue_key: str, expand: Optional[str] = None) -> Dict[str, Any]:
         """
         Fetch a single JIRA issue
@@ -83,43 +127,187 @@ class JiraClient:
             Issue data as dictionary
 
         Raises:
-            requests.HTTPError: If API request fails
+            Exception: If API request fails
         """
         url = urljoin(self.api_base, f'issue/{issue_key}')
         params = {}
         if expand:
             params['expand'] = expand
 
-        logging.debug(f"Fetching issue from: {url}")
-        if params:
-            logging.debug(f"Query parameters: {params}")
-
-        response = self.session.get(url, params=params)
-
-        # Log response details for debugging
-        logging.debug(f"Response status: {response.status_code}")
-        logging.debug(f"Response headers: {dict(response.headers)}")
-
-        if response.status_code == 401:
-            raise Exception("Authentication failed. Please check your credentials.")
-        elif response.status_code == 403:
-            raise Exception(f"Access denied to issue {issue_key}. Check permissions.")
-        elif response.status_code == 404:
-            raise Exception(f"Issue {issue_key} not found.")
-
-        response.raise_for_status()
-
-        return response.json()
+        return self._make_api_request(
+            url, 
+            params=params if params else None,
+            resource_name=f"Issue {issue_key}"
+        )
 
     def test_connection(self) -> Dict[str, Any]:
         """Test JIRA connection and authentication"""
         url = urljoin(self.api_base, 'myself')
-        logging.debug(f"Testing connection to: {url}")
+        return self._make_api_request(url, resource_name="User information")
 
-        response = self.session.get(url)
+    def get_remote_links(self, issue_key: str) -> List[Dict[str, Any]]:
+        """
+        Fetch remote links for a JIRA issue
 
-        if response.status_code == 401:
-            raise Exception("Authentication failed. Please check your credentials.")
+        Args:
+            issue_key: JIRA issue key (e.g., 'RFE-7877')
 
-        response.raise_for_status()
-        return response.json()
+        Returns:
+            List of remote link data
+
+        Raises:
+            Exception: If API request fails
+        """
+        url = urljoin(self.api_base, f'issue/{issue_key}/remotelink')
+        
+        return self._make_api_request(
+            url,
+            resource_name=f"remote links for issue {issue_key}",
+            handle_404_as_empty=True
+        )
+
+    def get_descendants(self, issue_key: str, depth: int = 0, 
+                       include_subtasks: bool = False, include_links: bool = False,
+                       include_remote_links: bool = False, expand: Optional[str] = None) -> Dict[str, Dict[str, Any]]:
+        """
+        Fetch an issue and its descendants based on specified relationship types and depth
+
+        Args:
+            issue_key: Starting JIRA issue key
+            depth: Maximum traversal depth (-1 for unlimited, 0 for issue only)
+            include_subtasks: Include subtask relationships
+            include_links: Include issue links
+            include_remote_links: Include remote links
+            expand: Comma-separated fields to expand for each issue
+
+        Returns:
+            Dictionary mapping issue keys to issue data
+
+        Raises:
+            Exception: If traversal encounters errors
+        """
+        issues = {}  # Dict[str, Dict[str, Any]]
+        visited = set()  # Set[str]
+        to_process = [(issue_key, 0)]  # List[(str, int)] - (issue_key, current_depth)
+
+        extraction_metadata = {
+            "start_issue": issue_key,
+            "max_depth": depth,
+            "include_subtasks": include_subtasks,
+            "include_links": include_links,
+            "include_remote_links": include_remote_links,
+            "traversal_order": []
+        }
+
+        while to_process:
+            current_key, current_depth = to_process.pop(0)
+            
+            # Skip if already processed
+            if current_key in visited:
+                continue
+                
+            visited.add(current_key)
+            extraction_metadata["traversal_order"].append({
+                "issue_key": current_key,
+                "depth": current_depth
+            })
+            
+            logging.info(f"Processing issue {current_key} at depth {current_depth}")
+            
+            try:
+                # Fetch the issue
+                issue_data = self.get_issue(current_key, expand=expand)
+                issues[current_key] = issue_data
+                
+                # Stop traversing deeper if we've reached the depth limit
+                if depth != -1 and current_depth >= depth:
+                    continue
+                
+                # Collect related issues to process next
+                related_issues = self._get_related_issue_keys(
+                    issue_data, current_key, include_subtasks, include_links, include_remote_links
+                )
+                
+                # Add related issues to processing queue
+                for related_key in related_issues:
+                    if related_key not in visited:
+                        to_process.append((related_key, current_depth + 1))
+                        
+            except Exception as e:
+                logging.warning(f"Failed to process issue {current_key}: {e}")
+                # Continue processing other issues
+                continue
+        
+        # Store extraction metadata in the result
+        issues["_extraction_metadata"] = extraction_metadata
+        
+        return issues
+
+    def _get_related_issue_keys(self, issue_data: Dict[str, Any], current_key: str,
+                               include_subtasks: bool, include_links: bool, 
+                               include_remote_links: bool) -> Set[str]:
+        """
+        Extract related issue keys from issue data based on relationship types
+
+        Args:
+            issue_data: Issue data from JIRA API
+            current_key: Current issue key (for logging)
+            include_subtasks: Include subtask relationships
+            include_links: Include issue links
+            include_remote_links: Include remote links
+
+        Returns:
+            Set of related issue keys
+        """
+        related_keys = set()
+        fields = issue_data.get('fields', {})
+        
+        # Process subtasks
+        if include_subtasks:
+            # Get subtasks (children)
+            subtasks = fields.get('subtasks', [])
+            for subtask in subtasks:
+                subtask_key = subtask.get('key')
+                if subtask_key:
+                    related_keys.add(subtask_key)
+                    logging.debug(f"Found subtask: {subtask_key}")
+            
+            # Get parent issue
+            parent = fields.get('parent')
+            if parent:
+                parent_key = parent.get('key')
+                if parent_key:
+                    related_keys.add(parent_key)
+                    logging.debug(f"Found parent: {parent_key}")
+        
+        # Process issue links
+        if include_links:
+            issue_links = fields.get('issuelinks', [])
+            for link in issue_links:
+                # Links can have inwardIssue or outwardIssue
+                inward_issue = link.get('inwardIssue')
+                if inward_issue:
+                    inward_key = inward_issue.get('key')
+                    if inward_key:
+                        related_keys.add(inward_key)
+                        link_type = link.get('type', {}).get('inward', 'related')
+                        logging.debug(f"Found inward link ({link_type}): {inward_key}")
+                
+                outward_issue = link.get('outwardIssue')
+                if outward_issue:
+                    outward_key = outward_issue.get('key')
+                    if outward_key:
+                        related_keys.add(outward_key)
+                        link_type = link.get('type', {}).get('outward', 'related')
+                        logging.debug(f"Found outward link ({link_type}): {outward_key}")
+        
+        # Process remote links (these don't lead to other JIRA issues, but we can fetch them for completeness)
+        if include_remote_links:
+            try:
+                remote_links = self.get_remote_links(current_key)
+                logging.debug(f"Found {len(remote_links)} remote links for {current_key}")
+                # Note: Remote links don't contribute to related_keys since they're external
+            except Exception as e:
+                logging.debug(f"Could not fetch remote links for {current_key}: {e}")
+        
+        return related_keys

--- a/jira_extractor/test_cli.py
+++ b/jira_extractor/test_cli.py
@@ -12,6 +12,7 @@ from unittest.mock import Mock, patch, mock_open
 import json
 import sys
 import requests
+import io
 
 from .cli import (
     setup_logging, validate_url, write_output, create_parser, main
@@ -910,6 +911,443 @@ class TestMainFunction(unittest.TestCase):
                 False,
                 None
             )
+
+
+class TestDescendantFunctions(unittest.TestCase):
+    """Test cases for descendant extraction functions"""
+
+    def test_parse_depth_valid_integers(self):
+        """Test parse_depth with valid integer strings"""
+        from jira_extractor.cli import parse_depth
+        
+        self.assertEqual(parse_depth("0"), 0)
+        self.assertEqual(parse_depth("1"), 1)
+        self.assertEqual(parse_depth("5"), 5)
+        self.assertEqual(parse_depth("100"), 100)
+
+    def test_parse_depth_all_keyword(self):
+        """Test parse_depth with 'all' keyword"""
+        from jira_extractor.cli import parse_depth
+        
+        self.assertEqual(parse_depth("all"), -1)
+        self.assertEqual(parse_depth("ALL"), -1)
+        self.assertEqual(parse_depth("All"), -1)
+
+    def test_parse_depth_invalid_values(self):
+        """Test parse_depth with invalid values"""
+        from jira_extractor.cli import parse_depth
+        
+        with self.assertRaises(ValueError) as cm:
+            parse_depth("invalid")
+        self.assertIn("Invalid depth value: invalid", str(cm.exception))
+
+        with self.assertRaises(ValueError) as cm:
+            parse_depth("-1")
+        self.assertIn("Use non-negative integer or 'all'", str(cm.exception))
+
+        with self.assertRaises(ValueError) as cm:
+            parse_depth("-5")
+        self.assertIn("Use non-negative integer or 'all'", str(cm.exception))
+
+    @patch('builtins.print')
+    def test_write_multiple_issues_stdout(self, mock_print):
+        """Test write_multiple_issues output to stdout"""
+        from jira_extractor.cli import write_multiple_issues
+        
+        issues = {
+            "TEST-1": {"key": "TEST-1", "fields": {"summary": "Test Issue 1"}},
+            "TEST-2": {"key": "TEST-2", "fields": {"summary": "Test Issue 2"}}
+        }
+        metadata = {"start_issue": "TEST-1", "total_extracted": 2}
+        
+        write_multiple_issues(issues, "-", extraction_metadata=metadata)
+        
+        # Check that print was called with JSON output
+        self.assertTrue(mock_print.called)
+        printed_output = mock_print.call_args[0][0]
+        self.assertIn("extraction_metadata", printed_output)
+        self.assertIn("issues", printed_output)
+        self.assertIn("TEST-1", printed_output)
+        self.assertIn("TEST-2", printed_output)
+
+    def test_write_multiple_issues_stdout_explicit(self):
+        """Test write_multiple_issues output to explicit stdout"""
+        from jira_extractor.cli import write_multiple_issues
+        
+        issues = {"TEST-1": {"key": "TEST-1", "fields": {"summary": "Test Issue 1"}}}
+        
+        with patch('builtins.print') as mock_print:
+            write_multiple_issues(issues, "stdout")
+            self.assertTrue(mock_print.called)
+
+    @patch('jira_extractor.cli.os.makedirs')
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('builtins.print')
+    def test_write_multiple_issues_directory(self, mock_print, mock_file_open, mock_makedirs):
+        """Test write_multiple_issues output to directory"""
+        from jira_extractor.cli import write_multiple_issues
+        
+        issues = {
+            "TEST-1": {
+                "key": "TEST-1",
+                "fields": {
+                    "summary": "Test Issue 1",
+                    "issuetype": {"name": "Bug"},
+                    "status": {"name": "Open"},
+                    "subtasks": [],
+                    "issuelinks": [],
+                    "comment": {"total": 5}
+                }
+            }
+        }
+        metadata = {"start_issue": "TEST-1"}
+        
+        write_multiple_issues(issues, "./output", extraction_metadata=metadata)
+        
+        # Verify directory creation
+        mock_makedirs.assert_called_once_with("./output", exist_ok=True)
+        
+        # Verify file writes (issue file + metadata file + summary file)
+        self.assertEqual(mock_file_open.call_count, 3)
+        
+        # Verify print statements
+        print_calls = [call[0][0] for call in mock_print.call_args_list]
+        self.assertTrue(any("Issue TEST-1 saved to" in call for call in print_calls))
+        self.assertTrue(any("Extraction summary saved to" in call for call in print_calls))
+        self.assertTrue(any("Total issues extracted: 1" in call for call in print_calls))
+
+    @patch('jira_extractor.cli.os.path.exists')
+    def test_write_multiple_issues_file_exists_no_overwrite(self, mock_exists):
+        """Test write_multiple_issues with existing file and no overwrite"""
+        from jira_extractor.cli import write_multiple_issues
+        
+        issues = {"TEST-1": {"key": "TEST-1", "fields": {"summary": "Test Issue 1"}}}
+        mock_exists.return_value = True
+        
+        with self.assertRaises(Exception) as cm:
+            write_multiple_issues(issues, "./output", overwrite=False)
+        
+        self.assertIn("already exists", str(cm.exception))
+        self.assertIn("Use --overwrite", str(cm.exception))
+
+    @patch('jira_extractor.cli.os.makedirs')
+    @patch('jira_extractor.cli.os.path.exists')
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('builtins.print')
+    def test_write_multiple_issues_file_exists_with_overwrite(self, mock_print, mock_file_open, mock_exists, mock_makedirs):
+        """Test write_multiple_issues with existing file and overwrite enabled"""
+        from jira_extractor.cli import write_multiple_issues
+        
+        issues = {"TEST-1": {"key": "TEST-1", "fields": {"summary": "Test Issue 1", "subtasks": [], "issuelinks": [], "comment": {"total": 0}}}}
+        mock_exists.return_value = True
+        
+        write_multiple_issues(issues, "./output", overwrite=True)
+        
+        # Should proceed without error
+        self.assertTrue(mock_file_open.called)
+
+
+class TestDescendantArgumentParser(unittest.TestCase):
+    """Test cases for descendant-related argument parsing"""
+
+    def test_parser_descendant_depth_option(self):
+        """Test parser with descendant depth option"""
+        from jira_extractor.cli import create_parser
+        
+        parser = create_parser()
+        args = parser.parse_args([
+            '-u', 'https://jira.example.com',
+            '-i', 'TEST-123',
+            '--descendant-depth', '2',
+            '--bearer-token', 'abc123'
+        ])
+        
+        self.assertEqual(args.descendant_depth, '2')
+        self.assertEqual(args.url, 'https://jira.example.com')
+        self.assertEqual(args.issue, 'TEST-123')
+
+    def test_parser_desc_depth_short_option(self):
+        """Test parser with short desc-depth option"""
+        from jira_extractor.cli import create_parser
+        
+        parser = create_parser()
+        args = parser.parse_args([
+            '-u', 'https://jira.example.com',
+            '-i', 'TEST-123',
+            '--desc-depth', 'all',
+            '--bearer-token', 'abc123'
+        ])
+        
+        self.assertEqual(args.descendant_depth, 'all')
+
+    def test_parser_relationship_options(self):
+        """Test parser with relationship traversal options"""
+        from jira_extractor.cli import create_parser
+        
+        parser = create_parser()
+        args = parser.parse_args([
+            '-u', 'https://jira.example.com',
+            '-i', 'TEST-123',
+            '--include-subtasks',
+            '--include-links',
+            '--include-remote-links',
+            '--bearer-token', 'abc123'
+        ])
+        
+        self.assertTrue(args.include_subtasks)
+        self.assertTrue(args.include_links)
+        self.assertTrue(args.include_remote_links)
+
+    def test_parser_descendant_defaults(self):
+        """Test parser defaults for descendant options"""
+        from jira_extractor.cli import create_parser
+        
+        parser = create_parser()
+        args = parser.parse_args([
+            '-u', 'https://jira.example.com',
+            '-i', 'TEST-123',
+            '--bearer-token', 'abc123'
+        ])
+        
+        self.assertEqual(args.descendant_depth, '0')
+        self.assertFalse(args.include_subtasks)
+        self.assertFalse(args.include_links)
+        self.assertFalse(args.include_remote_links)
+
+
+class TestMainFunctionDescendants(unittest.TestCase):
+    """Test cases for main function with descendant functionality"""
+
+    @patch('jira_extractor.cli.create_parser')
+    @patch('jira_extractor.cli.JiraClient')
+    @patch('jira_extractor.cli.write_multiple_issues')
+    def test_main_descendant_extraction_subtasks(self, mock_write_multiple, mock_jira_client, mock_create_parser):
+        """Test main function with descendant extraction including subtasks"""
+        from jira_extractor.cli import main
+        
+        # Setup parser mock
+        mock_parser = Mock()
+        mock_create_parser.return_value = mock_parser
+        
+        mock_args = Mock()
+        mock_args.url = 'https://jira.example.com'
+        mock_args.issue = 'PARENT-1'
+        mock_args.bearer_token = 'abc123'
+        mock_args.token = None
+        mock_args.username = None
+        mock_args.password = None
+        mock_args.output = '-'
+        mock_args.overwrite = False
+        mock_args.expand = None
+        mock_args.debug = False
+        mock_args.descendant_depth = '1'
+        mock_args.include_subtasks = True
+        mock_args.include_links = False
+        mock_args.include_remote_links = False
+        mock_parser.parse_args.return_value = mock_args
+        
+        # Setup client mock
+        mock_client_instance = Mock()
+        mock_jira_client.return_value = mock_client_instance
+        
+        # Mock descendants data
+        descendants_data = {
+            "PARENT-1": {"key": "PARENT-1", "fields": {"summary": "Parent Issue"}},
+            "CHILD-1": {"key": "CHILD-1", "fields": {"summary": "Child Issue"}},
+            "_extraction_metadata": {
+                "start_issue": "PARENT-1",
+                "total_issues": 2,
+                "include_subtasks": True
+            }
+        }
+        mock_client_instance.get_descendants.return_value = descendants_data
+        mock_client_instance.test_connection.return_value = {"displayName": "Test User"}
+        
+        main()
+        
+        # Verify client creation and method calls
+        mock_jira_client.assert_called_once_with('https://jira.example.com', 'bearer', token='abc123')
+        mock_client_instance.get_descendants.assert_called_once_with(
+            'PARENT-1',
+            depth=1,
+            include_subtasks=True,
+            include_links=False,
+            include_remote_links=False,
+            expand=None
+        )
+        
+        # Verify write_multiple_issues called (extraction_metadata removed from issues)
+        expected_issues = {
+            "PARENT-1": {"key": "PARENT-1", "fields": {"summary": "Parent Issue"}},
+            "CHILD-1": {"key": "CHILD-1", "fields": {"summary": "Child Issue"}}
+        }
+        expected_metadata = {
+            "start_issue": "PARENT-1", 
+            "total_issues": 2,
+            "include_subtasks": True
+        }
+        mock_write_multiple.assert_called_once_with(
+            expected_issues, '-', False, None, expected_metadata
+        )
+
+    @patch('jira_extractor.cli.create_parser')
+    @patch('jira_extractor.cli.JiraClient')
+    @patch('jira_extractor.cli.write_multiple_issues')
+    def test_main_descendant_extraction_unlimited_depth(self, mock_write_multiple, mock_jira_client, mock_create_parser):
+        """Test main function with unlimited depth descendant extraction"""
+        from jira_extractor.cli import main
+        
+        # Setup parser mock
+        mock_parser = Mock()
+        mock_create_parser.return_value = mock_parser
+        
+        mock_args = Mock()
+        mock_args.url = 'https://jira.example.com'
+        mock_args.issue = 'ROOT-1'
+        mock_args.bearer_token = 'abc123'
+        mock_args.token = None
+        mock_args.username = None
+        mock_args.password = None
+        mock_args.output = './output'
+        mock_args.overwrite = True
+        mock_args.expand = 'comments'
+        mock_args.debug = False
+        mock_args.descendant_depth = 'all'
+        mock_args.include_subtasks = True
+        mock_args.include_links = True
+        mock_args.include_remote_links = False
+        mock_parser.parse_args.return_value = mock_args
+        
+        # Setup client mock
+        mock_client_instance = Mock()
+        mock_jira_client.return_value = mock_client_instance
+        
+        # Mock descendants data
+        descendants_data = {
+            "ROOT-1": {"key": "ROOT-1"},
+            "CHILD-1": {"key": "CHILD-1"},
+            "GRANDCHILD-1": {"key": "GRANDCHILD-1"},
+            "_extraction_metadata": {"start_issue": "ROOT-1", "max_depth": -1}
+        }
+        mock_client_instance.get_descendants.return_value = descendants_data
+        mock_client_instance.test_connection.return_value = {"displayName": "Test User"}
+        
+        main()
+        
+        # Verify get_descendants called with unlimited depth
+        mock_client_instance.get_descendants.assert_called_once_with(
+            'ROOT-1',
+            depth=-1,
+            include_subtasks=True,
+            include_links=True,
+            include_remote_links=False,
+            expand='comments'
+        )
+
+    @patch('jira_extractor.cli.create_parser')
+    @patch('jira_extractor.cli.JiraClient')
+    @patch('sys.stderr', new_callable=io.StringIO)
+    def test_main_descendant_no_issues_extracted(self, mock_stderr, mock_jira_client, mock_create_parser):
+        """Test main function when no issues are extracted"""
+        from jira_extractor.cli import main
+        
+        # Setup parser mock
+        mock_parser = Mock()
+        mock_create_parser.return_value = mock_parser
+        
+        mock_args = Mock()
+        mock_args.url = 'https://jira.example.com'
+        mock_args.issue = 'MISSING-1'
+        mock_args.bearer_token = 'abc123'
+        mock_args.token = None
+        mock_args.username = None
+        mock_args.password = None
+        mock_args.output = '-'
+        mock_args.overwrite = False
+        mock_args.expand = None
+        mock_args.debug = False
+        mock_args.descendant_depth = '1'
+        mock_args.include_subtasks = True
+        mock_args.include_links = False
+        mock_args.include_remote_links = False
+        mock_parser.parse_args.return_value = mock_args
+        
+        # Setup client mock - return empty result
+        mock_client_instance = Mock()
+        mock_jira_client.return_value = mock_client_instance
+        mock_client_instance.get_descendants.return_value = {"_extraction_metadata": {}}
+        mock_client_instance.test_connection.return_value = {"displayName": "Test User"}
+        
+        with self.assertRaises(SystemExit) as cm:
+            main()
+        
+        self.assertEqual(cm.exception.code, 1)
+
+    @patch('jira_extractor.cli.create_parser')
+    @patch('jira_extractor.cli.JiraClient')
+    @patch('jira_extractor.cli.write_output')
+    def test_main_single_issue_mode_fallback(self, mock_write_output, mock_jira_client, mock_create_parser):
+        """Test main function falls back to single issue mode when no descendant options"""
+        from jira_extractor.cli import main
+        
+        # Setup parser mock with no descendant options
+        mock_parser = Mock()
+        mock_create_parser.return_value = mock_parser
+        
+        mock_args = Mock()
+        mock_args.url = 'https://jira.example.com'
+        mock_args.issue = 'TEST-123'
+        mock_args.bearer_token = 'abc123'
+        mock_args.token = None
+        mock_args.username = None
+        mock_args.password = None
+        mock_args.output = '-'
+        mock_args.overwrite = False
+        mock_args.expand = None
+        mock_args.debug = False
+        mock_args.descendant_depth = '0'  # Default value
+        mock_args.include_subtasks = False
+        mock_args.include_links = False
+        mock_args.include_remote_links = False
+        mock_parser.parse_args.return_value = mock_args
+        
+        # Setup client mock
+        mock_client_instance = Mock()
+        mock_jira_client.return_value = mock_client_instance
+        mock_client_instance.get_issue.return_value = {"key": "TEST-123", "fields": {"summary": "Test Issue"}}
+        mock_client_instance.test_connection.return_value = {"displayName": "Test User"}
+        
+        main()
+        
+        # Verify single issue mode is used
+        mock_client_instance.get_issue.assert_called_once_with('TEST-123', expand=None)
+        mock_write_output.assert_called_once()
+        
+        # Verify descendants method is NOT called
+        mock_client_instance.get_descendants.assert_not_called()
+
+    @patch('jira_extractor.cli.create_parser')
+    def test_main_invalid_depth_parameter(self, mock_create_parser):
+        """Test main function with invalid depth parameter"""
+        from jira_extractor.cli import main
+        
+        # Setup parser mock
+        mock_parser = Mock()
+        mock_create_parser.return_value = mock_parser
+        
+        mock_args = Mock()
+        mock_args.url = 'https://jira.example.com'
+        mock_args.issue = 'TEST-123'
+        mock_args.bearer_token = 'abc123'
+        mock_args.descendant_depth = 'invalid'
+        mock_parser.parse_args.return_value = mock_args
+        
+        with patch('sys.stderr', new_callable=io.StringIO) as mock_stderr:
+            with self.assertRaises(SystemExit) as cm:
+                main()
+            
+            self.assertEqual(cm.exception.code, 1)
+            self.assertIn("Invalid depth value: invalid", mock_stderr.getvalue())
 
 
 if __name__ == '__main__':

--- a/jira_extractor/test_cli.py
+++ b/jira_extractor/test_cli.py
@@ -323,7 +323,8 @@ class TestMainFunction(unittest.TestCase):
         
         # Setup mocks
         mock_client_instance = Mock()
-        mock_client_instance.get_issue.return_value = {"key": "TEST-123"}
+        mock_client_instance.get_issue.return_value = {"key": "TEST-123", "fields": {"summary": "Test Issue"}}
+        mock_client_instance.test_connection.return_value = {"displayName": "Test User"}
         mock_jira_client.return_value = mock_client_instance
         
         with patch('argparse.ArgumentParser.parse_args') as mock_parse_args:
@@ -342,6 +343,8 @@ class TestMainFunction(unittest.TestCase):
             mock_args.include_subtasks = False
             mock_args.include_links = False
             mock_args.include_remote_links = False
+            mock_args.include_parent_links = False
+            mock_args.parent_link_field = 'Parent Link'
             mock_parse_args.return_value = mock_args
             
             main()
@@ -349,11 +352,13 @@ class TestMainFunction(unittest.TestCase):
             # Verify client creation
             mock_jira_client.assert_called_once_with(
                 'https://jira.example.com',
-                'bearer',
-                token='abc123'
+                username=None,
+                password=None,
+                token=None,
+                bearer_token='abc123'
             )
             
-            # Verify issue retrieval
+            # Verify issue retrieval (single issue mode)
             mock_client_instance.get_issue.assert_called_once_with('TEST-123', expand=None)
             
             # Verify output writing
@@ -432,6 +437,8 @@ class TestMainFunction(unittest.TestCase):
             mock_args.include_subtasks = False
             mock_args.include_links = False
             mock_args.include_remote_links = False
+            mock_args.include_parent_links = False
+            mock_args.parent_link_field = 'Parent Link'
             mock_parse_args.return_value = mock_args
             
             main()
@@ -439,7 +446,10 @@ class TestMainFunction(unittest.TestCase):
             # Verify client creation with no auth
             mock_jira_client.assert_called_once_with(
                 'https://issues.redhat.com',
-                None
+                username=None,
+                password=None,
+                token=None,
+                bearer_token=None
             )
             
             # Verify no connection test was performed
@@ -513,6 +523,8 @@ class TestMainFunction(unittest.TestCase):
             mock_args.include_subtasks = False
             mock_args.include_links = False
             mock_args.include_remote_links = False
+            mock_args.include_parent_links = False
+            mock_args.parent_link_field = 'Parent Link'
             mock_parse_args.return_value = mock_args
             
             main()
@@ -520,9 +532,10 @@ class TestMainFunction(unittest.TestCase):
             # Verify client creation with token auth
             mock_jira_client.assert_called_once_with(
                 'https://jira.example.com',
-                'token',
                 username='testuser',
-                token='abc123'
+                password=None,
+                token='abc123',
+                bearer_token=None
             )
             
             # Verify connection test was performed
@@ -570,6 +583,8 @@ class TestMainFunction(unittest.TestCase):
             mock_args.include_subtasks = False
             mock_args.include_links = False
             mock_args.include_remote_links = False
+            mock_args.include_parent_links = False
+            mock_args.parent_link_field = 'Parent Link'
             mock_parse_args.return_value = mock_args
             
             main()
@@ -580,9 +595,10 @@ class TestMainFunction(unittest.TestCase):
             # Verify client creation with basic auth
             mock_jira_client.assert_called_once_with(
                 'https://jira.example.com',
-                'basic',
                 username='testuser',
-                password='prompted_password'
+                password='prompted_password',
+                token=None,
+                bearer_token=None
             )
             
             # Verify output was written
@@ -661,6 +677,8 @@ class TestMainFunction(unittest.TestCase):
             mock_args.include_subtasks = False
             mock_args.include_links = False
             mock_args.include_remote_links = False
+            mock_args.include_parent_links = False
+            mock_args.parent_link_field = 'Parent Link'
             mock_parse_args.return_value = mock_args
             
             with self.assertRaises(SystemExit):
@@ -707,6 +725,8 @@ class TestMainFunction(unittest.TestCase):
             mock_args.include_subtasks = False
             mock_args.include_links = False
             mock_args.include_remote_links = False
+            mock_args.include_parent_links = False
+            mock_args.parent_link_field = 'Parent Link'
             mock_parse_args.return_value = mock_args
             
             with self.assertRaises(SystemExit):
@@ -753,6 +773,8 @@ class TestMainFunction(unittest.TestCase):
             mock_args.include_subtasks = False
             mock_args.include_links = False
             mock_args.include_remote_links = False
+            mock_args.include_parent_links = False
+            mock_args.parent_link_field = 'Parent Link'
             mock_parse_args.return_value = mock_args
             
             with self.assertRaises(SystemExit):
@@ -801,6 +823,8 @@ class TestMainFunction(unittest.TestCase):
             mock_args.include_subtasks = False
             mock_args.include_links = False
             mock_args.include_remote_links = False
+            mock_args.include_parent_links = False
+            mock_args.parent_link_field = 'Parent Link'
             mock_parse_args.return_value = mock_args
             
             with self.assertRaises(SystemExit):
@@ -850,6 +874,8 @@ class TestMainFunction(unittest.TestCase):
             mock_args.include_subtasks = False
             mock_args.include_links = False
             mock_args.include_remote_links = False
+            mock_args.include_parent_links = False
+            mock_args.parent_link_field = 'Parent Link'
             mock_parse_args.return_value = mock_args
             
             with self.assertRaises(SystemExit):
@@ -899,6 +925,8 @@ class TestMainFunction(unittest.TestCase):
             mock_args.include_subtasks = False
             mock_args.include_links = False
             mock_args.include_remote_links = False
+            mock_args.include_parent_links = False
+            mock_args.parent_link_field = 'Parent Link'
             mock_parse_args.return_value = mock_args
             
             main()
@@ -1144,6 +1172,8 @@ class TestMainFunctionDescendants(unittest.TestCase):
         mock_args.include_subtasks = True
         mock_args.include_links = False
         mock_args.include_remote_links = False
+        mock_args.include_parent_links = False
+        mock_args.parent_link_field = 'Parent Link'
         mock_parser.parse_args.return_value = mock_args
         
         # Setup client mock
@@ -1166,13 +1196,15 @@ class TestMainFunctionDescendants(unittest.TestCase):
         main()
         
         # Verify client creation and method calls
-        mock_jira_client.assert_called_once_with('https://jira.example.com', 'bearer', token='abc123')
+        mock_jira_client.assert_called_once_with('https://jira.example.com', username=None, password=None, token=None, bearer_token='abc123')
         mock_client_instance.get_descendants.assert_called_once_with(
             'PARENT-1',
             depth=1,
             include_subtasks=True,
             include_links=False,
             include_remote_links=False,
+            include_parent_links=False,
+            parent_link_field='Parent Link',
             expand=None
         )
         
@@ -1216,6 +1248,8 @@ class TestMainFunctionDescendants(unittest.TestCase):
         mock_args.include_subtasks = True
         mock_args.include_links = True
         mock_args.include_remote_links = False
+        mock_args.include_parent_links = False
+        mock_args.parent_link_field = 'Parent Link'
         mock_parser.parse_args.return_value = mock_args
         
         # Setup client mock
@@ -1241,6 +1275,8 @@ class TestMainFunctionDescendants(unittest.TestCase):
             include_subtasks=True,
             include_links=True,
             include_remote_links=False,
+            include_parent_links=False,
+            parent_link_field='Parent Link',
             expand='comments'
         )
 
@@ -1309,6 +1345,8 @@ class TestMainFunctionDescendants(unittest.TestCase):
         mock_args.include_subtasks = False
         mock_args.include_links = False
         mock_args.include_remote_links = False
+        mock_args.include_parent_links = False
+        mock_args.parent_link_field = 'Parent Link'
         mock_parser.parse_args.return_value = mock_args
         
         # Setup client mock

--- a/jira_extractor/test_cli.py
+++ b/jira_extractor/test_cli.py
@@ -337,6 +337,10 @@ class TestMainFunction(unittest.TestCase):
             mock_args.overwrite = False
             mock_args.expand = None
             mock_args.debug = False
+            mock_args.descendant_depth = '0'
+            mock_args.include_subtasks = False
+            mock_args.include_links = False
+            mock_args.include_remote_links = False
             mock_parse_args.return_value = mock_args
             
             main()
@@ -377,6 +381,10 @@ class TestMainFunction(unittest.TestCase):
             mock_args.username = None
             mock_args.password = None
             mock_args.debug = False
+            mock_args.descendant_depth = '0'
+            mock_args.include_subtasks = False
+            mock_args.include_links = False
+            mock_args.include_remote_links = False
             mock_parse_args.return_value = mock_args
             
             with self.assertRaises(SystemExit):
@@ -419,6 +427,10 @@ class TestMainFunction(unittest.TestCase):
             mock_args.overwrite = False
             mock_args.expand = None
             mock_args.debug = False
+            mock_args.descendant_depth = '0'
+            mock_args.include_subtasks = False
+            mock_args.include_links = False
+            mock_args.include_remote_links = False
             mock_parse_args.return_value = mock_args
             
             main()
@@ -447,6 +459,10 @@ class TestMainFunction(unittest.TestCase):
             mock_args = Mock()
             mock_args.url = 'bad-url'
             mock_args.debug = False
+            mock_args.descendant_depth = '0'
+            mock_args.include_subtasks = False
+            mock_args.include_links = False
+            mock_args.include_remote_links = False
             mock_parse_args.return_value = mock_args
             
             with self.assertRaises(SystemExit):
@@ -492,6 +508,10 @@ class TestMainFunction(unittest.TestCase):
             mock_args.overwrite = False
             mock_args.expand = None
             mock_args.debug = False
+            mock_args.descendant_depth = '0'
+            mock_args.include_subtasks = False
+            mock_args.include_links = False
+            mock_args.include_remote_links = False
             mock_parse_args.return_value = mock_args
             
             main()
@@ -545,6 +565,10 @@ class TestMainFunction(unittest.TestCase):
             mock_args.overwrite = False
             mock_args.expand = None
             mock_args.debug = False
+            mock_args.descendant_depth = '0'
+            mock_args.include_subtasks = False
+            mock_args.include_links = False
+            mock_args.include_remote_links = False
             mock_parse_args.return_value = mock_args
             
             main()
@@ -586,6 +610,10 @@ class TestMainFunction(unittest.TestCase):
             mock_args.username = None
             mock_args.password = 'secret'
             mock_args.debug = False
+            mock_args.descendant_depth = '0'
+            mock_args.include_subtasks = False
+            mock_args.include_links = False
+            mock_args.include_remote_links = False
             mock_parse_args.return_value = mock_args
             
             with self.assertRaises(SystemExit):
@@ -628,6 +656,10 @@ class TestMainFunction(unittest.TestCase):
             mock_args.overwrite = False
             mock_args.expand = None
             mock_args.debug = False
+            mock_args.descendant_depth = '0'
+            mock_args.include_subtasks = False
+            mock_args.include_links = False
+            mock_args.include_remote_links = False
             mock_parse_args.return_value = mock_args
             
             with self.assertRaises(SystemExit):
@@ -670,6 +702,10 @@ class TestMainFunction(unittest.TestCase):
             mock_args.overwrite = False
             mock_args.expand = None
             mock_args.debug = False
+            mock_args.descendant_depth = '0'
+            mock_args.include_subtasks = False
+            mock_args.include_links = False
+            mock_args.include_remote_links = False
             mock_parse_args.return_value = mock_args
             
             with self.assertRaises(SystemExit):
@@ -712,6 +748,10 @@ class TestMainFunction(unittest.TestCase):
             mock_args.overwrite = False
             mock_args.expand = None
             mock_args.debug = False
+            mock_args.descendant_depth = '0'
+            mock_args.include_subtasks = False
+            mock_args.include_links = False
+            mock_args.include_remote_links = False
             mock_parse_args.return_value = mock_args
             
             with self.assertRaises(SystemExit):
@@ -756,6 +796,10 @@ class TestMainFunction(unittest.TestCase):
             mock_args.overwrite = False
             mock_args.expand = None
             mock_args.debug = True
+            mock_args.descendant_depth = '0'
+            mock_args.include_subtasks = False
+            mock_args.include_links = False
+            mock_args.include_remote_links = False
             mock_parse_args.return_value = mock_args
             
             with self.assertRaises(SystemExit):
@@ -801,6 +845,10 @@ class TestMainFunction(unittest.TestCase):
             mock_args.overwrite = False
             mock_args.expand = None
             mock_args.debug = False
+            mock_args.descendant_depth = '0'
+            mock_args.include_subtasks = False
+            mock_args.include_links = False
+            mock_args.include_remote_links = False
             mock_parse_args.return_value = mock_args
             
             with self.assertRaises(SystemExit):
@@ -846,6 +894,10 @@ class TestMainFunction(unittest.TestCase):
             mock_args.overwrite = False
             mock_args.expand = None
             mock_args.debug = False
+            mock_args.descendant_depth = '0'
+            mock_args.include_subtasks = False
+            mock_args.include_links = False
+            mock_args.include_remote_links = False
             mock_parse_args.return_value = mock_args
             
             main()

--- a/jira_extractor/test_client.py
+++ b/jira_extractor/test_client.py
@@ -174,7 +174,8 @@ class TestJiraClient(unittest.TestCase):
         
         with self.assertRaises(Exception) as cm:
             client.get_issue(self.test_issue_key)
-        self.assertIn(f"Access denied to issue {self.test_issue_key}", str(cm.exception))
+
+        self.assertIn(f"Access denied to Issue {self.test_issue_key}. Check permissions.", str(cm.exception))
     
     @patch('jira_extractor.client.requests.Session.get')
     def test_get_issue_404_error(self, mock_get):
@@ -220,7 +221,7 @@ class TestJiraClient(unittest.TestCase):
         result = client.test_connection()
         
         expected_url = f"{self.base_url}/rest/api/2/myself"
-        mock_get.assert_called_once_with(expected_url)
+        mock_get.assert_called_once_with(expected_url, params={})
         self.assertEqual(result["displayName"], "Test User")
     
     @patch('jira_extractor.client.requests.Session.get')
@@ -235,6 +236,7 @@ class TestJiraClient(unittest.TestCase):
         
         with self.assertRaises(Exception) as cm:
             client.test_connection()
+
         self.assertIn("Authentication failed", str(cm.exception))
     
     @patch('jira_extractor.client.requests.Session.get')
@@ -255,7 +257,7 @@ class TestJiraClient(unittest.TestCase):
         debug_calls = [call[0][0] for call in mock_logging.debug.call_args_list]
         
         # Check that URL and parameters are logged
-        self.assertTrue(any("Fetching issue from:" in call for call in debug_calls))
+        self.assertTrue(any("Making API request to:" in call for call in debug_calls))
         self.assertTrue(any("Query parameters:" in call for call in debug_calls))
         self.assertTrue(any("Response status:" in call for call in debug_calls))
         self.assertTrue(any("Response headers:" in call for call in debug_calls))


### PR DESCRIPTION
- Add --descendant-depth/--desc-depth CLI argument for explicit depth control
- Add relationship traversal options: --include-subtasks, --include-links, --include-remote-links
- Implement get_descendants() method with breadth-first traversal
- Add get_remote_links() method for external link extraction
- Centralize API error handling in _make_api_request() helper method
- Add write_multiple_issues() for multi-issue output with extraction summary
- Update CLI examples and help text for new descendant functionality
- Prepare foundation for future ancestor extraction features

Assisted-by: Cursor (Claude)